### PR TITLE
modify queries to return date and also add date when creating a recipe

### DIFF
--- a/controllers/queries.js
+++ b/controllers/queries.js
@@ -32,7 +32,7 @@ export const getCategoryId = async (categoryName) => {
 // Get basic info (recipeName, user) of ALL recipes
 export const getAllRecipes = async () => {
     const [rows] = await pool.query(`
-    SELECT r.recipe_id, r.name, u.username, MIN(i.image_id) AS image_id
+    SELECT r.recipe_id, r.name, u.username, MIN(i.image_id) AS image_id, r.date
     FROM users u
     INNER JOIN recipes r ON u.user_id = r.user_id
     LEFT JOIN images i ON r.recipe_id = i.recipe_id
@@ -44,7 +44,7 @@ export const getAllRecipes = async () => {
 // Get basic info (recipeName, user) of recipes by categoryName
 export const getRecipesByCategoryName = async (categoryName) => {
     const [rows] = await pool.query(`
-    SELECT r.recipe_id, r.name, u.username, MIN(i.image_id) AS image_id
+    SELECT r.recipe_id, r.name, u.username, MIN(i.image_id) AS image_id, r.date
     FROM users u
     INNER JOIN recipes r ON u.user_id = r.user_id
     INNER JOIN recipe_categories rc ON r.recipe_id = rc.recipe_id
@@ -60,7 +60,7 @@ export const getRecipesByCategoryName = async (categoryName) => {
 // Get basic info (recipeName, user) of recipes by recipeName
 export const getRecipesByRecipeName = async (recipeName) => {
     const [rows] = await pool.query(`
-    SELECT r.recipe_id, r.name, u.username, MIN(i.image_id) AS image_id
+    SELECT r.recipe_id, r.name, u.username, MIN(i.image_id) AS image_id, r.date
     FROM users u
     INNER JOIN recipes r ON u.user_id = r.user_id
     LEFT JOIN images i ON r.recipe_id = i.recipe_id
@@ -74,7 +74,7 @@ export const getRecipesByRecipeName = async (recipeName) => {
 // Get info (name, description, username, price_range) of a single recipe by recipe_id
 export const getRecipeInfo = async (recipeId) => {
     const [row] = await pool.query(`
-    SELECT r.recipe_id, r.name, r.description, u.username, r.time_hours, r.time_minutes, r.price_range
+    SELECT r.recipe_id, r.name, r.description, u.username, r.time_hours, r.time_minutes, r.price_range, r.date
     FROM users u
     INNER JOIN recipes r ON u.user_id = r.user_id
     WHERE r.recipe_id = ?`, [recipeId])
@@ -241,8 +241,8 @@ export const getUserByEmail = async (email) => {
 // Insert basic info of a recipe into recipes table
 export const createRecipe = async (userId, name, description, time_h, time_m, price) => {
     const [result] = await pool.query(`
-    INSERT INTO recipes (user_id, name, description, time_hours, time_minutes, price_range)
-    VALUES (?, ?, ?, ?, ?, ?)`, [userId, name, description, time_h, time_m, price])
+    INSERT INTO recipes (user_id, name, description, time_hours, time_minutes, price_range, date)
+    VALUES (?, ?, ?, ?, ?, ?, now())`, [userId, name, description, time_h, time_m, price])
 
     const id = result.insertId
     return getRecipeInfo(id)


### PR DESCRIPTION
Modify your local database with the following command:

`ALTER TABLE recipes
ADD COLUMN date DATE;`

Then it should be good to go to work with the newly added "date" column in the recipes table!

For the queries that get recipes, the date is now returned as well.

No need to worry about sending a date when creating a recipe, as it is added automatically when the POST request is made!